### PR TITLE
Update ytdl-core to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "discord.js": "^11.5.1",
     "events": "^3.0.0",
     "moment-timezone": "^0.5.26",
-    "ytdl-core": "^0.29.7",
+    "ytdl-core": "^1.0.1",
     "ytpl": "^0.1.16",
     "ytsearcher": "^1.2.2"
   },


### PR DESCRIPTION
The older version gives out an error: 
```js
cannot find module
```